### PR TITLE
Refine Makefile

### DIFF
--- a/c_impl/Makefile
+++ b/c_impl/Makefile
@@ -1,11 +1,11 @@
-.PHONY: all clean
+.PHONY: all test clean
 
 CC := cc
 CFLAGS := -Wextra -Wall -g
 
 TARGET = tinyvm
 SRCS = \
-	$(shell find ./ -name "*.c" -maxdepth 1) \
+	$(shell find ./ -maxdepth 1 -name "*.c") \
 	$(shell find ./sds -name "*.c")
 OBJS = $(shell find ./ -name "*.o")
 
@@ -17,18 +17,23 @@ TEST_SRCS = \
 	$(shell find ./sds -name "*.c") \
 	$(shell find ./tests -name "*.c")
 
-all: $(TARGET) $(TEST_TARGET)
+all: $(TARGET)
 
-test: $(TEST_TARGET)
+test: build_test run_test
+
+build_test: $(TEST_TARGET)
+
+run_test:
+	$(GENERATED)/$(TEST_TARGET)
 
 $(TARGET): $(SRCS) | $(GENERATED)
 	$(CC) -o $(addprefix $(GENERATED)/, $@) $^ $(CFLAGS)
 
 $(TEST_TARGET): $(TEST_SRCS) | $(GENERATED)
-	$(CC) -o $(addprefix $(GENERATED)/, $@) $^ $(CFLAGS)  -I .
+	$(CC) -o $(addprefix $(GENERATED)/, $@) $^ $(CFLAGS)  -I ./
 
 $(GENERATED):
-	mkdir -p $(GENERATED)
+	@mkdir -p $(GENERATED)
 
 clean:
-	$(RM) $(OBJS) $(addprefix $(GENERATED)/, $(TARGET))
+	$(RM) $(OBJS) $(addprefix $(GENERATED)/, $(TARGET) $(TEST_TARGET))


### PR DESCRIPTION
* `make all` Only builds the tinyvm binary.
* `make test` builds and runs tests.
* `make build_test` only builds the binary for tests.